### PR TITLE
Fix Cache.isValid() returning stale value (async fs.access in sync method)

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -54,14 +54,16 @@ export class Cache {
   }
 
   isValid() {
-    fs.access(this.CacheFile, fs.constants.F_OK | fs.constants.W_OK, (err) => {
-      if (!err) {
-        const cache = this.read();
-        const now = Date.now();
-        this.valid = now - cache.cache_time < cache.ttl;
-      }
-    });
+    this.valid = false;
 
+    try {
+      fs.accessSync(this.CacheFile, fs.constants.F_OK | fs.constants.W_OK);
+    } catch {
+      return false;
+    }
+
+    const cache = this.read();
+    this.valid = Date.now() - cache.cache_time < cache.ttl;
     return this.valid;
   }
 }


### PR DESCRIPTION
## Summary

Fixes a latent bug in [`Cache.isValid()`](https://github.com/peledies/homebridge-ambient-weather-sensors/blob/main/src/cache.ts#L56-L66): the method calls the **callback** form of `fs.access` (which is async) from a synchronous method, then returns `this.valid` before the callback ever fires.

## Behavior before this fix

```ts
isValid() {
  fs.access(this.CacheFile, ..., (err) => {
    if (!err) {
      const cache = this.read();
      this.valid = now - cache.cache_time < cache.ttl;   // ← runs LATER, after we already returned
    }
  });

  return this.valid;   // ← returns the value from the PREVIOUS invocation (or false on first call)
}
```

Net effect: `isValid()` returns the result of the *previous* check, not the current one. On a cold start, the first call returns `false` (initial value), so the disk cache is bypassed and the API gets hit. By the time the callback finishes, the next call returns whatever the previous cycle decided — usually correct in steady state, but always one invocation behind reality, and incorrectly stale if the cache file was just deleted or expired.

## Fix

Swap the async callback form for `fs.accessSync`, and explicitly reset `this.valid = false` at the top so a now-missing or now-stale cache file can't keep returning `true` from a previous run:

```ts
isValid() {
  this.valid = false;

  try {
    fs.accessSync(this.CacheFile, fs.constants.F_OK | fs.constants.W_OK);
  } catch {
    return false;
  }

  const cache = this.read();
  this.valid = Date.now() - cache.cache_time < cache.ttl;
  return this.valid;
}
```

## Why it matters

`fetchDevices()` calls `this.Cache.isValid()` to decide whether to use the disk cache or hit the AWN API. With the bug, every cold start (and any cycle following a transient miss) hits the API even when a valid cache exists on disk — increasing the chance of running into AWN's 1 req/s/apiKey rate limit, especially when N accessories' poll timers fire in parallel.

## Test plan

- [x] `npm run build` clean
- [x] Plugin loads in Homebridge with cache hits taking effect from the first poll forward
- [x] Cache miss path still works (no cache file → `isValid()` returns `false` cleanly)

## Note

This is unrelated to Homebridge 2 compatibility — submitted as a separate PR alongside #21 to keep each one focused.